### PR TITLE
Add mobx use subscription + react state

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ in your browser, and click the button very quickly. (check the console log)
       ✓ check 5: updated properly with transition (2629ms)
       ✕ check 6: no tearing with transition (2ms)
       ✕ check 7: proper branching with transition (5583ms)
+  mobx-use-sub
+    check with events from outside
+      ✓ check 1: updated properly (8644ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (1145ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (3528ms)
+      ✓ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (6437ms)
   use-subscription
     check with events from outside
       ✓ check 1: updated properly (8579ms)
@@ -165,6 +175,16 @@ in your browser, and click the button very quickly. (check the console log)
       ✓ check 5: updated properly with transition (4536ms)
       ✓ check 6: no tearing with transition (1ms)
       ✕ check 7: proper branching with transition (7426ms)
+  react-state
+    check with events from outside
+      ✓ check 1: updated properly (8118ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (2141ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (3417ms)
+      ✓ check 6: no tearing with transition (1ms)
+      ✓ check 7: proper branching with transition (2435ms)
 ```
 
 </details>
@@ -300,6 +320,27 @@ in your browser, and click the button very quickly. (check the console log)
     <td>Pass</td>
     <td>Pass</td>
     <td>Fail</td>
+  </tr>
+
+  <tr>
+    <th>Mobx (w/use-subscription)</th>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Fail</td>
+  </tr>
+    <tr>
+    <th>React State</th>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ in your browser, and click the button very quickly. (check the console log)
     <td>Pass</td>
     <td>Fail</td>
   </tr>
-    <tr>
+  <tr>
     <th>React State</th>
     <td>Pass</td>
     <td>Pass</td>

--- a/__tests__/all_spec.js
+++ b/__tests__/all_spec.js
@@ -13,8 +13,10 @@ const names = [
   'react-hooks-global-state',
   'use-context-selector',
   'mobx-react-lite',
+  'mobx-use-sub',
   'use-subscription',
   'salvoravida-react-redux',
+  'react-state',
 ];
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "build:mobx-react-lite": "cross-env NAME=mobx-react-lite webpack",
     "build:use-subscription": "cross-env NAME=use-subscription webpack",
     "build:salvoravida-react-redux": "cross-env NAME=salvoravida-react-redux webpack",
+    "build:react-state": "cross-env NAME=react-state webpack",
+    "build:mobx-use-sub": "cross-env NAME=mobx-use-sub webpack",
     "build-all": "run-s build:*"
   },
   "keywords": [

--- a/src/mobx-use-sub/index.js
+++ b/src/mobx-use-sub/index.js
@@ -1,0 +1,83 @@
+import React, { createContext, useContext, useTransition } from 'react';
+import { useLocalStore } from 'mobx-react-lite';
+
+import * as mobx from 'mobx';
+import { useSubscription } from 'use-subscription';
+import {
+  syncBlock,
+  useRegisterIncrementDispatcher,
+  initialState,
+  ids,
+  useCheckTearing,
+  shallowEqual,
+} from '../common';
+
+function useCount(store) {
+  return useSubscription(React.useMemo(() => ({
+    getCurrentValue: () => store.count,
+    subscribe: (cb) => {
+      return mobx.autorun(cb);
+    },
+  }), [store]));
+}
+
+const Ctx = createContext();
+
+const Counter = React.memo(() => {
+  const store = useContext(Ctx);
+  const count = useCount(store);
+  syncBlock();
+  return <div className="count">{count}</div>;
+}, shallowEqual);
+
+const Main = () => {
+  const store = useContext(Ctx);
+  useCheckTearing();
+  useRegisterIncrementDispatcher(React.useCallback(() => {
+    store.dummy += 1;
+    if (store.dummy % 2 === 1) {
+      store.count += 1;
+    }
+  }, [store]));
+  const [localCount, localIncrement] = React.useReducer(c => c + 1, 0);
+  const normalIncrement = () => {
+    store.dummy += 1;
+    if (store.dummy % 2 === 1) {
+      store.count += 1;
+    }
+  };
+  const [startTransition, isPending] = useTransition();
+  const transitionIncrement = () => {
+    startTransition(() => {
+      store.dummy += 1;
+      if (store.dummy % 2 === 1) {
+        store.count += 1;
+      }
+    });
+  };
+  const count = useCount(store);
+  return (
+    <div>
+      <button type="button" id="normalIncrement" onClick={normalIncrement}>Increment shared count normally (two clicks to increment one)</button>
+      <button type="button" id="transitionIncrement" onClick={transitionIncrement}>Increment shared count in transition (two clicks to increment one)</button>
+      <span id="pending">{isPending && 'Pending...'}</span>
+      <h1>Shared Count</h1>
+      {ids.map(id => <Counter key={id} />)}
+      <div className="count">{count}</div>
+      <h1>Local Count</h1>
+      {localCount}
+      <button type="button" id="localIncrement" onClick={localIncrement}>Increment local count</button>
+    </div>
+  );
+};
+
+const App = () => {
+  const store = useLocalStore(() => initialState);
+  return (
+    <Ctx.Provider value={store}>
+      <Main />
+    </Ctx.Provider>
+  );
+};
+
+export default App;

--- a/src/react-state/index.js
+++ b/src/react-state/index.js
@@ -8,7 +8,7 @@ import {
   reducer,
   initialState,
 } from '../common';
-console.log('react-state')
+
 const Ctx = createContext();
 
 const Counter = React.memo(() => {

--- a/src/react-state/index.js
+++ b/src/react-state/index.js
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useTransition } from 'react';
+import {
+  syncBlock,
+  useRegisterIncrementDispatcher,
+  ids,
+  useCheckTearing,
+  shallowEqual,
+  reducer,
+  initialState,
+} from '../common';
+console.log('react-state')
+const Ctx = createContext();
+
+const Counter = React.memo(() => {
+  const store = useContext(Ctx);
+  syncBlock();
+  return <div className="count">{store}</div>;
+}, shallowEqual);
+
+const Main = ({ dispatch }) => {
+  const store = useContext(Ctx);
+  useCheckTearing();
+  useRegisterIncrementDispatcher(React.useCallback(() => {
+    console.log('here');
+    dispatch({ type: 'increment' });
+  }, [dispatch]));
+  const [localCount, localIncrement] = React.useReducer(c => c + 1, 0);
+  const normalIncrement = () => {
+    dispatch({ type: 'increment' });
+  };
+  const [startTransition, isPending] = useTransition();
+  const transitionIncrement = () => {
+    startTransition(() => {
+      dispatch({ type: 'increment' });
+    });
+  };
+
+  return (
+    <div>
+      <button type="button" id="normalIncrement" onClick={normalIncrement}>Increment shared count normally (two clicks to increment one)</button>
+      <button type="button" id="transitionIncrement" onClick={transitionIncrement}>Increment shared count in transition (two clicks to increment one)</button>
+      <span id="pending">{isPending && 'Pending...'}</span>
+      <h1>Shared Count</h1>
+      {ids.map(id => <Counter key={id} />)}
+      <div className="count">{store}</div>
+      <h1>Local Count</h1>
+      {localCount}
+      <button type="button" id="localIncrement" onClick={localIncrement}>Increment local count</button>
+    </div>
+  );
+};
+
+const App = () => {
+  const [store, dispatch] = React.useReducer(reducer, initialState);
+
+  return (
+    <Ctx.Provider value={store.count}>
+      <Main dispatch={dispatch} />
+    </Ctx.Provider>
+  );
+};
+
+export default App;


### PR DESCRIPTION
This PR adds a version of mobx using `use-subscription` and also adds a basic react state version, designed to just be a sanity check