### PR TITLE
add simplux

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ in your browser, and click the button very quickly. (check the console log)
       ✓ check 5: updated properly with transition (3417ms)
       ✓ check 6: no tearing with transition (1ms)
       ✓ check 7: proper branching with transition (2435ms)
+  simplux
+    check with events from outside
+      √ check 1: updated properly (8570ms)
+      √ check 2: no tearing during update (1ms)
+      √ check 3: ability to interrupt render
+      √ check 4: proper update after interrupt (2381ms)
+    check with useTransaction
+      √ check 5: updated properly with transition (3510ms)
+      √ check 6: no tearing with transition (2ms)
+      × check 7: proper branching with transition (5459ms)
 ```
 
 </details>
@@ -341,6 +351,17 @@ in your browser, and click the button very quickly. (check the console log)
     <td>Pass</td>
     <td>Pass</td>
     <td>Pass</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/MrWolfZ/simplux">simplux</a></th>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Pass</td>
+    <td>Fail</td>
   </tr>
 </table>
 

--- a/__tests__/all_spec.js
+++ b/__tests__/all_spec.js
@@ -17,6 +17,7 @@ const names = [
   'use-subscription',
   'salvoravida-react-redux',
   'react-state',
+  'simplux',
 ];
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,23 @@
         "react-is": "^16.9.0"
       }
     },
+    "@simplux/core": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@simplux/core/-/core-0.10.2.tgz",
+      "integrity": "sha512-huLkL/iye5mM3huqZCYoes5hk3VIayBK+qZaxj+pKcfhQ3ScQH6RHhOH0UNM7yVHDUnqbSqFreAPBj5pjwmNBA==",
+      "requires": {
+        "immer": "^5.0.0",
+        "redux": ">=4.0.0"
+      }
+    },
+    "@simplux/react": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@simplux/react/-/react-0.10.2.tgz",
+      "integrity": "sha512-isTDmDd/zLyiFgHuk92mOYmotND75QM1taGy/U/zMDO3J9apfl1LLRVSuVxvSjYaH5GOfiQHNlTVmPgi8Z6Unw==",
+      "requires": {
+        "@simplux/core": "0.10.2"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -5692,6 +5709,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-5.0.0.tgz",
+      "integrity": "sha512-G7gRqKbi9NE025XVyqyTV98dxUOtdKvu/P1QRaVZfA55aEcXgjbxPdm+TlWdcSMNPKijlaHNz61DGPyelouRlA=="
     },
     "import-fresh": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:salvoravida-react-redux": "cross-env NAME=salvoravida-react-redux webpack",
     "build:react-state": "cross-env NAME=react-state webpack",
     "build:mobx-use-sub": "cross-env NAME=mobx-use-sub webpack",
+    "build:simplux": "cross-env NAME=simplux webpack",
     "build-all": "run-s build:*"
   },
   "keywords": [
@@ -38,6 +39,8 @@
   "license": "MIT",
   "dependencies": {
     "@salvoravida/react-redux": "^7.1.9",
+    "@simplux/core": "^0.10.2",
+    "@simplux/react": "^0.10.2",
     "constate": "^1.3.2",
     "mobx": "^5.15.0",
     "mobx-react-lite": "^2.0.0-alpha.2",

--- a/src/simplux/index.js
+++ b/src/simplux/index.js
@@ -1,0 +1,75 @@
+import React, { useTransition } from 'react';
+import { createSimpluxModule, createMutations, createSelectors } from '@simplux/core';
+import { SimpluxProvider, useSimplux } from '@simplux/react';
+
+import {
+  syncBlock,
+  useRegisterIncrementDispatcher,
+  ids,
+  useCheckTearing,
+  shallowEqual,
+  initialState,
+} from '../common';
+
+const counterModule = createSimpluxModule({
+  name: 'counter',
+  initialState,
+});
+
+const counter = {
+  ...counterModule,
+  ...createMutations(counterModule, {
+    increment(state) {
+      state.dummy += 1;
+      state.count += state.dummy % 2 === 0 ? 1 : 0;
+    },
+  }),
+  ...createSelectors(counterModule, {
+    value: state => state.count,
+  }),
+};
+
+const Counter = React.memo(() => {
+  const count = useSimplux(counter.value);
+  syncBlock();
+  return <div className="count">{count}</div>;
+}, shallowEqual);
+
+const Main = () => {
+  const count = useSimplux(counter.value);
+  useCheckTearing();
+  useRegisterIncrementDispatcher(React.useCallback(() => {
+    counter.increment();
+  }, []));
+  const [localCount, localIncrement] = React.useReducer(c => c + 1, 0);
+  const normalIncrement = () => {
+    counter.increment();
+  };
+  const [startTransition, isPending] = useTransition();
+  const transitionIncrement = () => {
+    startTransition(() => {
+      counter.increment();
+    });
+  };
+  return (
+    <div>
+      <button type="button" id="normalIncrement" onClick={normalIncrement}>Increment shared count normally (two clicks to increment one)</button>
+      <button type="button" id="transitionIncrement" onClick={transitionIncrement}>Increment shared count in transition (two clicks to increment one)</button>
+      <span id="pending">{isPending && 'Pending...'}</span>
+      <h1>Shared Count</h1>
+      {ids.map(id => <Counter key={id} />)}
+      <div className="count">{count}</div>
+      <h1>Local Count</h1>
+      {localCount}
+      <button type="button" id="localIncrement" onClick={localIncrement}>Increment local count</button>
+    </div>
+  );
+};
+
+const App = () => (
+  <SimpluxProvider>
+    <Main />
+  </SimpluxProvider>
+);
+
+export default App;


### PR DESCRIPTION
I've been working on my own little state management library called [simplux](https://github.com/MrWolfZ/simplux) and I'd like to throw my hat in the ring for it.

Since it is based on Redux (and therefore uses an external store) it fails check 7, but everything else looks good.

As you can see, I have made the table entry a link to the repository. Would it maybe make sense to do this for all projects to make it easier to find them if someone is interested?