### PR TITLE
Add test for react-apollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,154 +57,154 @@ in your browser, and click the button very quickly. (check the console log)
 ```
   react-redux
     check with events from outside
-      ✓ check 1: updated properly (3143ms)
+      ✓ check 1: updated properly (3278ms)
       ✕ check 2: no tearing during update (22ms)
       ✓ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (1432ms)
+      ✓ check 4: proper update after interrupt (1496ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2467ms)
+      ✓ check 5: updated properly with transition (2536ms)
       ✕ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5416ms)
+      ✕ check 7: proper branching with transition (5430ms)
   reactive-react-redux
     check with events from outside
-      ✓ check 1: updated properly (3075ms)
+      ✓ check 1: updated properly (3182ms)
       ✓ check 2: no tearing during update (2ms)
       ✓ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (1136ms)
+      ✓ check 4: proper update after interrupt (1361ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2409ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (7398ms)
+      ✓ check 5: updated properly with transition (2476ms)
+      ✓ check 6: no tearing with transition (5ms)
+      ✕ check 7: proper branching with transition (7427ms)
   react-tracked
     check with events from outside
-      ✓ check 1: updated properly (8108ms)
-      ✓ check 2: no tearing during update
+      ✓ check 1: updated properly (8379ms)
+      ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2136ms)
+      ✓ check 4: proper update after interrupt (2462ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3425ms)
+      ✓ check 5: updated properly with transition (3532ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✓ check 7: proper branching with transition (3512ms)
+      ✓ check 7: proper branching with transition (3716ms)
   constate
     check with events from outside
-      ✓ check 1: updated properly (8109ms)
-      ✓ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2135ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (4541ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✓ check 7: proper branching with transition (4385ms)
-  zustand
-    check with events from outside
-      ✓ check 1: updated properly (3134ms)
-      ✕ check 2: no tearing during update (22ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1385ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (2458ms)
-      ✕ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5436ms)
-  react-sweet-state
-    check with events from outside
-      ✓ check 1: updated properly (10921ms)
-      ✕ check 2: no tearing during update (1ms)
-      ✕ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (2433ms)
-    check with useTransaction
-      ✕ check 5: updated properly with transition (3930ms)
-      ✕ check 6: no tearing with transition (40ms)
-      ✕ check 7: proper branching with transition (8677ms)
-  storeon
-    check with events from outside
-      ✓ check 1: updated properly (3132ms)
-      ✕ check 2: no tearing during update (20ms)
-      ✓ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (1383ms)
-    check with useTransaction
-      ✕ check 5: updated properly with transition (2587ms)
-      ✓ check 6: no tearing with transition (19ms)
-      ✕ check 7: proper branching with transition (7411ms)
-  react-hooks-global-state
-    check with events from outside
-      ✓ check 1: updated properly (8612ms)
-      ✓ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2141ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (3412ms)
-      ✓ check 6: no tearing with transition (3ms)
-      ✓ check 7: proper branching with transition (2402ms)
-  use-context-selector
-    check with events from outside
-      ✓ check 1: updated properly (8629ms)
-      ✓ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1058ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (3415ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✓ check 7: proper branching with transition (3509ms)
-  mobx-react-lite
-    check with events from outside
-      ✓ check 1: updated properly (2805ms)
-      ✕ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1374ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (2587ms)
-      ✕ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5578ms)
-  use-subscription
-    check with events from outside
-      ✓ check 1: updated properly (8621ms)
+      ✓ check 1: updated properly (8146ms)
       ✓ check 2: no tearing during update
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1124ms)
-    check with useTransaction
-      ✓ check 5: updated properly with transition (4427ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (7418ms)
-  mobx-use-sub
-    check with events from outside
-      ✓ check 1: updated properly (8473ms)
-      ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
       ✓ check 4: proper update after interrupt (1134ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3538ms)
+      ✓ check 5: updated properly with transition (4692ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✕ check 7: proper branching with transition (6438ms)
-  react-state
+      ✓ check 7: proper branching with transition (4512ms)
+  zustand
     check with events from outside
-      ✓ check 1: updated properly (8103ms)
+      ✓ check 1: updated properly (3257ms)
+      ✕ check 2: no tearing during update (24ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (1465ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (2520ms)
+      ✕ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (5425ms)
+  react-sweet-state
+    check with events from outside
+      ✓ check 1: updated properly (11066ms)
+      ✕ check 2: no tearing during update (1ms)
+      ✕ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (2426ms)
+    check with useTransaction
+      ✕ check 5: updated properly with transition (3980ms)
+      ✕ check 6: no tearing with transition (40ms)
+      ✕ check 7: proper branching with transition (8695ms)
+  storeon
+    check with events from outside
+      ✓ check 1: updated properly (3237ms)
+      ✕ check 2: no tearing during update (21ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (1476ms)
+    check with useTransaction
+      ✕ check 5: updated properly with transition (2646ms)
+      ✓ check 6: no tearing with transition (19ms)
+      ✕ check 7: proper branching with transition (7421ms)
+  react-hooks-global-state
+    check with events from outside
+      ✓ check 1: updated properly (8373ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (2447ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (3531ms)
+      ✓ check 6: no tearing with transition (4ms)
+      ✓ check 7: proper branching with transition (3712ms)
+  use-context-selector
+    check with events from outside
+      ✓ check 1: updated properly (8383ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2124ms)
+      ✓ check 4: proper update after interrupt (1349ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3409ms)
+      ✓ check 5: updated properly with transition (3551ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✓ check 7: proper branching with transition (2599ms)
-  simplux
+      ✓ check 7: proper branching with transition (3617ms)
+  mobx-react-lite
     check with events from outside
-      ✓ check 1: updated properly (8611ms)
+      ✓ check 1: updated properly (2885ms)
+      ✕ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (1337ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (2632ms)
+      ✕ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (5565ms)
+  use-subscription
+    check with events from outside
+      ✓ check 1: updated properly (8657ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (2378ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (4595ms)
+      ✓ check 6: no tearing with transition (1ms)
+      ✕ check 7: proper branching with transition (7426ms)
+  mobx-use-sub
+    check with events from outside
+      ✓ check 1: updated properly (8387ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (2444ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (3646ms)
+      ✓ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (6440ms)
+  react-state
+    check with events from outside
+      ✓ check 1: updated properly (8404ms)
       ✓ check 2: no tearing during update (2ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1107ms)
+      ✓ check 4: proper update after interrupt (2273ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3438ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5437ms)
+      ✓ check 5: updated properly with transition (3570ms)
+      ✓ check 6: no tearing with transition (4ms)
+      ✓ check 7: proper branching with transition (2522ms)
+  simplux
+    check with events from outside
+      ✓ check 1: updated properly (8445ms)
+      ✓ check 2: no tearing during update (1ms)
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (1139ms)
+    check with useTransaction
+      ✓ check 5: updated properly with transition (3561ms)
+      ✓ check 6: no tearing with transition (6ms)
+      ✕ check 7: proper branching with transition (5404ms)
   react-apollo
     check with events from outside
-      ✕ check 1: updated properly (11918ms)
-      ✕ check 2: no tearing during update (3ms)
+      ✓ check 1: updated properly (3380ms)
+      ✕ check 2: no tearing during update (21ms)
       ✓ check 3: ability to interrupt render
-      ✕ check 4: proper update after interrupt (5088ms)
+      ✕ check 4: proper update after interrupt (5189ms)
     check with useTransaction
-      ✕ check 5: updated properly with transition (5616ms)
-      ✕ check 6: no tearing with transition (3ms)
-      ✕ check 7: proper branching with transition (5453ms)
+      ✓ check 5: updated properly with transition (3528ms)
+      ✕ check 6: no tearing with transition (6ms)
+      ✕ check 7: proper branching with transition (5455ms)
 ```
 
 </details>
@@ -376,11 +376,11 @@ in your browser, and click the button very quickly. (check the console log)
 
   <tr>
     <th><a href="https://github.com/apollographql/react-apollo">react-apollo</a></th>
-    <td>Fail</td>
+    <td>Pass</td>
     <td>Fail</td>
     <td>Pass</td>
     <td>Fail</td>
-    <td>Fail</td>
+    <td>Pass</td>
     <td>Fail</td>
     <td>Fail</td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -57,144 +57,154 @@ in your browser, and click the button very quickly. (check the console log)
 ```
   react-redux
     check with events from outside
-      ✓ check 1: updated properly (3232ms)
-      ✕ check 2: no tearing during update (23ms)
+      ✓ check 1: updated properly (3143ms)
+      ✕ check 2: no tearing during update (22ms)
       ✓ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (1477ms)
+      ✓ check 4: proper update after interrupt (1432ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2584ms)
+      ✓ check 5: updated properly with transition (2467ms)
       ✕ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5441ms)
+      ✕ check 7: proper branching with transition (5416ms)
   reactive-react-redux
     check with events from outside
-      ✓ check 1: updated properly (3140ms)
-      ✓ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1247ms)
+      ✓ check 1: updated properly (3075ms)
+      ✓ check 2: no tearing during update (2ms)
+      ✓ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (1136ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2487ms)
+      ✓ check 5: updated properly with transition (2409ms)
       ✓ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (7411ms)
+      ✕ check 7: proper branching with transition (7398ms)
   react-tracked
     check with events from outside
-      ✓ check 1: updated properly (8811ms)
-      ✓ check 2: no tearing during update (1ms)
+      ✓ check 1: updated properly (8108ms)
+      ✓ check 2: no tearing during update
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1332ms)
+      ✓ check 4: proper update after interrupt (2136ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3537ms)
+      ✓ check 5: updated properly with transition (3425ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✓ check 7: proper branching with transition (2512ms)
+      ✓ check 7: proper branching with transition (3512ms)
   constate
     check with events from outside
-      ✓ check 1: updated properly (8548ms)
+      ✓ check 1: updated properly (8109ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2358ms)
+      ✓ check 4: proper update after interrupt (2135ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3618ms)
+      ✓ check 5: updated properly with transition (4541ms)
       ✓ check 6: no tearing with transition (2ms)
-      ✓ check 7: proper branching with transition (4494ms)
+      ✓ check 7: proper branching with transition (4385ms)
   zustand
     check with events from outside
-      ✓ check 1: updated properly (3289ms)
-      ✕ check 2: no tearing during update (20ms)
+      ✓ check 1: updated properly (3134ms)
+      ✕ check 2: no tearing during update (22ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1459ms)
+      ✓ check 4: proper update after interrupt (1385ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2513ms)
-      ✕ check 6: no tearing with transition (1ms)
-      ✕ check 7: proper branching with transition (5500ms)
+      ✓ check 5: updated properly with transition (2458ms)
+      ✕ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (5436ms)
   react-sweet-state
     check with events from outside
-      ✓ check 1: updated properly (10535ms)
+      ✓ check 1: updated properly (10921ms)
       ✕ check 2: no tearing during update (1ms)
       ✕ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (2416ms)
+      ✓ check 4: proper update after interrupt (2433ms)
     check with useTransaction
-      ✕ check 5: updated properly with transition (3875ms)
+      ✕ check 5: updated properly with transition (3930ms)
       ✕ check 6: no tearing with transition (40ms)
-      ✕ check 7: proper branching with transition (8700ms)
+      ✕ check 7: proper branching with transition (8677ms)
   storeon
     check with events from outside
-      ✓ check 1: updated properly (3183ms)
-      ✕ check 2: no tearing during update (21ms)
-      ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1425ms)
+      ✓ check 1: updated properly (3132ms)
+      ✕ check 2: no tearing during update (20ms)
+      ✓ check 3: ability to interrupt render (1ms)
+      ✓ check 4: proper update after interrupt (1383ms)
     check with useTransaction
-      ✕ check 5: updated properly with transition (2641ms)
-      ✓ check 6: no tearing with transition (20ms)
-      ✕ check 7: proper branching with transition (7425ms)
+      ✕ check 5: updated properly with transition (2587ms)
+      ✓ check 6: no tearing with transition (19ms)
+      ✕ check 7: proper branching with transition (7411ms)
   react-hooks-global-state
     check with events from outside
-      ✓ check 1: updated properly (8195ms)
+      ✓ check 1: updated properly (8612ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1271ms)
+      ✓ check 4: proper update after interrupt (2141ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3541ms)
-      ✓ check 6: no tearing with transition (2ms)
-      ✓ check 7: proper branching with transition (2643ms)
+      ✓ check 5: updated properly with transition (3412ms)
+      ✓ check 6: no tearing with transition (3ms)
+      ✓ check 7: proper branching with transition (2402ms)
   use-context-selector
     check with events from outside
-      ✓ check 1: updated properly (8173ms)
+      ✓ check 1: updated properly (8629ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2288ms)
+      ✓ check 4: proper update after interrupt (1058ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3504ms)
-      ✓ check 6: no tearing with transition (1ms)
-      ✓ check 7: proper branching with transition (2680ms)
+      ✓ check 5: updated properly with transition (3415ms)
+      ✓ check 6: no tearing with transition (2ms)
+      ✓ check 7: proper branching with transition (3509ms)
   mobx-react-lite
     check with events from outside
-      ✓ check 1: updated properly (2878ms)
+      ✓ check 1: updated properly (2805ms)
       ✕ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1357ms)
+      ✓ check 4: proper update after interrupt (1374ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (2656ms)
+      ✓ check 5: updated properly with transition (2587ms)
       ✕ check 6: no tearing with transition (2ms)
-      ✕ check 7: proper branching with transition (5585ms)
+      ✕ check 7: proper branching with transition (5578ms)
   use-subscription
     check with events from outside
-      ✓ check 1: updated properly (8171ms)
-      ✓ check 2: no tearing during update (1ms)
-      ✓ check 3: ability to interrupt render (1ms)
-      ✓ check 4: proper update after interrupt (1097ms)
+      ✓ check 1: updated properly (8621ms)
+      ✓ check 2: no tearing during update
+      ✓ check 3: ability to interrupt render
+      ✓ check 4: proper update after interrupt (1124ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3525ms)
-      ✓ check 6: no tearing with transition (1ms)
-      ✕ check 7: proper branching with transition (7425ms)
+      ✓ check 5: updated properly with transition (4427ms)
+      ✓ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (7418ms)
   mobx-use-sub
     check with events from outside
-      ✓ check 1: updated properly (8544ms)
+      ✓ check 1: updated properly (8473ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2207ms)
+      ✓ check 4: proper update after interrupt (1134ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3625ms)
+      ✓ check 5: updated properly with transition (3538ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✕ check 7: proper branching with transition (6463ms)
+      ✕ check 7: proper branching with transition (6438ms)
   react-state
     check with events from outside
-      ✓ check 1: updated properly (8805ms)
+      ✓ check 1: updated properly (8103ms)
       ✓ check 2: no tearing during update (1ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (1302ms)
+      ✓ check 4: proper update after interrupt (2124ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3507ms)
+      ✓ check 5: updated properly with transition (3409ms)
       ✓ check 6: no tearing with transition (1ms)
-      ✓ check 7: proper branching with transition (2512ms)
+      ✓ check 7: proper branching with transition (2599ms)
   simplux
     check with events from outside
-      ✓ check 1: updated properly (8834ms)
-      ✓ check 2: no tearing during update (1ms)
+      ✓ check 1: updated properly (8611ms)
+      ✓ check 2: no tearing during update (2ms)
       ✓ check 3: ability to interrupt render
-      ✓ check 4: proper update after interrupt (2193ms)
+      ✓ check 4: proper update after interrupt (1107ms)
     check with useTransaction
-      ✓ check 5: updated properly with transition (3514ms)
-      ✓ check 6: no tearing with transition (1ms)
-      ✕ check 7: proper branching with transition (5442ms)
+      ✓ check 5: updated properly with transition (3438ms)
+      ✓ check 6: no tearing with transition (2ms)
+      ✕ check 7: proper branching with transition (5437ms)
+  react-apollo
+    check with events from outside
+      ✕ check 1: updated properly (11918ms)
+      ✕ check 2: no tearing during update (3ms)
+      ✓ check 3: ability to interrupt render
+      ✕ check 4: proper update after interrupt (5088ms)
+    check with useTransaction
+      ✕ check 5: updated properly with transition (5616ms)
+      ✕ check 6: no tearing with transition (3ms)
+      ✕ check 7: proper branching with transition (5453ms)
 ```
 
 </details>
@@ -361,6 +371,17 @@ in your browser, and click the button very quickly. (check the console log)
     <td>Pass</td>
     <td>Pass</td>
     <td>Pass</td>
+    <td>Fail</td>
+  </tr>
+
+  <tr>
+    <th><a href="https://github.com/apollographql/react-apollo">react-apollo</a></th>
+    <td>Fail</td>
+    <td>Fail</td>
+    <td>Pass</td>
+    <td>Fail</td>
+    <td>Fail</td>
+    <td>Fail</td>
     <td>Fail</td>
   </tr>
 </table>

--- a/__tests__/all_spec.js
+++ b/__tests__/all_spec.js
@@ -17,6 +17,7 @@ const names = [
   'mobx-use-sub',
   'react-state',
   'simplux',
+  'react-apollo',
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/react-common": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.3.tgz",
+      "integrity": "sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.3.tgz",
+      "integrity": "sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
     "@babel/cli": {
       "version": "7.7.7",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.7.tgz",
@@ -1314,8 +1334,7 @@
     "@types/node": {
       "version": "13.1.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.5.tgz",
-      "integrity": "sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g==",
-      "dev": true
+      "integrity": "sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1337,6 +1356,11 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
+    },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -1514,6 +1538,23 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1666,6 +1707,110 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
+      }
+    },
+    "apollo-boost": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.7.tgz",
+      "integrity": "sha512-jfc3aqO0vpCV+W662EOG5gq4AH94yIsvSgAUuDvS3o/Z+8Joqn4zGC9CgLCDHusK30mFgtsEgwEe0pZoedohsQ==",
+      "requires": {
+        "apollo-cache": "^1.3.4",
+        "apollo-cache-inmemory": "^1.6.5",
+        "apollo-client": "^2.6.7",
+        "apollo-link": "^1.0.6",
+        "apollo-link-error": "^1.0.3",
+        "apollo-link-http": "^1.3.1",
+        "graphql-tag": "^2.4.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "apollo-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.4.tgz",
+      "integrity": "sha512-7X5aGbqaOWYG+SSkCzJNHTz2ZKDcyRwtmvW4mGVLRqdQs+HxfXS4dUS2CcwrAj449se6tZ6NLUMnjko4KMt3KA==",
+      "requires": {
+        "apollo-utilities": "^1.3.3",
+        "tslib": "^1.10.0"
+      }
+    },
+    "apollo-cache-inmemory": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.5.tgz",
+      "integrity": "sha512-koB76JUDJaycfejHmrXBbWIN9pRKM0Z9CJGQcBzIOtmte1JhEBSuzsOUu7NQgiXKYI4iGoMREcnaWffsosZynA==",
+      "requires": {
+        "apollo-cache": "^1.3.4",
+        "apollo-utilities": "^1.3.3",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "apollo-client": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.8.tgz",
+      "integrity": "sha512-0zvJtAcONiozpa5z5zgou83iEKkBaXhhSSXJebFHRXs100SecDojyUWKjwTtBPn9HbM6o5xrvC5mo9VQ5fgAjw==",
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.4",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.3",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.0"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.20"
+      }
+    },
+    "apollo-link-error": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.12.tgz",
+      "integrity": "sha512-psNmHyuy3valGikt/XHJfe0pKJnRX19tLLs6P6EHRxg+6q6JMXNVLYPaQBkL0FkwdTCB0cbFJAGRYCBviG8TDA==",
+      "requires": {
+        "apollo-link": "^1.2.13",
+        "apollo-link-http-common": "^0.2.15",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz",
+      "integrity": "sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==",
+      "requires": {
+        "apollo-link": "^1.2.13",
+        "apollo-link-http-common": "^0.2.15",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz",
+      "integrity": "sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==",
+      "requires": {
+        "apollo-link": "^1.2.13",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
+      "integrity": "sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
       }
     },
     "aproba": {
@@ -4273,8 +4418,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5363,6 +5507,19 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "graphql": {
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -6293,6 +6450,11 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest": {
       "version": "24.9.0",
@@ -8028,6 +8190,14 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "requires": {
+        "@wry/context": "^0.4.0"
       }
     },
     "optimist": {
@@ -10472,11 +10642,18 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -11644,6 +11821,20 @@
       "dev": true,
       "requires": {
         "fd-slicer": "~1.0.1"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     },
     "zustand": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:react-state": "cross-env NAME=react-state webpack",
     "build:mobx-use-sub": "cross-env NAME=mobx-use-sub webpack",
     "build:simplux": "cross-env NAME=simplux webpack",
+    "build:react-apollo": "cross-env NAME=react-apollo webpack",
     "build-all": "run-s build:*"
   },
   "keywords": [
@@ -38,10 +39,13 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@apollo/react-hooks": "^3.1.3",
     "@salvoravida/react-redux": "^7.1.9",
     "@simplux/core": "^0.11.1",
     "@simplux/react": "^0.11.1",
+    "apollo-boost": "^0.4.7",
     "constate": "^1.3.2",
+    "graphql": "^14.5.8",
     "mobx": "^5.15.1",
     "mobx-react-lite": "^2.0.0-alpha.2",
     "react": "experimental",

--- a/src/react-apollo/index.js
+++ b/src/react-apollo/index.js
@@ -1,0 +1,119 @@
+import React, { useTransition } from 'react';
+import ApolloClient, { gql, InMemoryCache } from 'apollo-boost';
+import { ApolloProvider, useQuery, useMutation } from '@apollo/react-hooks';
+
+import {
+  syncBlock,
+  useRegisterIncrementDispatcher,
+  ids,
+  useCheckTearing,
+  shallowEqual,
+} from '../common';
+
+const typeDefs = gql`
+  type Query {
+    count: Int!
+  }
+  type Mutation {
+    increment: Bool!
+  }
+`;
+
+const COUNT_QUERY = gql`
+  query CountQuery {
+    count @client
+  }
+`;
+
+const INCREMENT_MUTATION = gql`
+  mutation IncrementMutation {
+    increment @client
+  }
+`;
+
+const cacheInstance = new InMemoryCache();
+cacheInstance.writeQuery({
+  query: COUNT_QUERY,
+  data: {
+    count: 0,
+  },
+});
+
+const client = new ApolloClient({
+  cache: cacheInstance,
+  clientState: {
+    typeDefs,
+    resolvers: {
+      Query: {
+        count(root, args, { cache }) {
+          const { count } = cache.readQuery({
+            query: COUNT_QUERY,
+          });
+          return count;
+        },
+      },
+      Mutation: {
+        increment(root, args, { cache }) {
+          const { count } = cache.readQuery({
+            query: COUNT_QUERY,
+          });
+          cache.writeQuery({
+            query: COUNT_QUERY,
+            data: {
+              count: count + 1,
+            },
+          });
+          return true;
+        },
+      },
+    },
+  },
+});
+
+const Counter = React.memo(() => {
+  const { loading, error, data } = useQuery(COUNT_QUERY, { fetchPolicy: 'cache-only' });
+  syncBlock();
+  return <div className="count">{(!loading && !error && data) ? data.count : 0}</div>;
+}, shallowEqual);
+
+const Main = () => {
+  const [increment] = useMutation(INCREMENT_MUTATION);
+  const { loading, data, error } = useQuery(COUNT_QUERY, { fetchPolicy: 'cache-only' });
+  useCheckTearing();
+  useRegisterIncrementDispatcher(React.useCallback(() => {
+    increment();
+  }, [increment]));
+  const [localCount, localIncrement] = React.useReducer((c) => c + 1, 0);
+  const normalIncrement = () => {
+    increment();
+  };
+  const [startTransition, isPending] = useTransition();
+  const transitionIncrement = () => {
+    startTransition(() => {
+      increment();
+    });
+  };
+  return (
+    <div>
+      <button type="button" id="normalIncrement" onClick={normalIncrement}>Increment shared count normally (two clicks to increment one)</button>
+      <button type="button" id="transitionIncrement" onClick={transitionIncrement}>Increment shared count in transition (two clicks to increment one)</button>
+      <span id="pending">{isPending && 'Pending...'}</span>
+      <h1>Shared Count</h1>
+      {ids.map((id) => <Counter key={id} />)}
+      <div className="count">
+        {(!loading && !error && data) ? data.count : 0}
+      </div>
+      <h1>Local Count</h1>
+      {localCount}
+      <button type="button" id="localIncrement" onClick={localIncrement}>Increment local count</button>
+    </div>
+  );
+};
+
+const App = () => (
+  <ApolloProvider client={client}>
+    <Main />
+  </ApolloProvider>
+);
+
+export default App;


### PR DESCRIPTION
Hello @dai-shi, this is a pretty interesting experiment and pretty sure to have a big impact on the react ecosystems.

I'm using apollo-client in production, and I suspected the same problem since it also manages the global state (inmemory-cache) and using custom subscription internally.

And the result is:

```
  react-apollo
    check with events from outside
      ✓ check 1: updated properly (3380ms)
      ✕ check 2: no tearing during update (21ms)
      ✓ check 3: ability to interrupt render
      ✕ check 4: proper update after interrupt (5189ms)
    check with useTransaction
      ✓ check 5: updated properly with transition (3528ms)
      ✕ check 6: no tearing with transition (6ms)
      ✕ check 7: proper branching with transition (5455ms)
```

They're doing massive refactoring for v3 right now, but not sure if they've considered this.

I wanna report this to the apollo core team. Please let me know if anything goes wrong here. Thank you for the great insight.